### PR TITLE
Build Docker images using GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish to Docker
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: gamedrivendesign/godot-export
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        godot_version: [3.0, 3.0.1]
+        godot_version: ["3.0", "3.0.1"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -19,7 +19,7 @@ jobs:
       env:
         GODOT_VERSION: ${{ matrix.godot_version }}
       with:
-        name: gamedrivendesign/godot-export
+        name: "gamedrivendesign/godot-export:${{ matrix.godot_version }}"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: GODOT_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Docker
+name: Publish to DockerHub
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: The latest version must be at the very end (it will additionally be pushed as "latest")
+        # Note: Make sure to adjust the godot_version down below in the build-latest job when
+        # adding a new version to this array.
         godot_version: ["3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.1", "3.1.1"]
     runs-on: ubuntu-latest
     steps:
@@ -24,8 +25,14 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: GODOT_VERSION
+  build-latest:
+    strategy:
+      matrix:
+        godot_version: ["3.1.1"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
     - name: Push Godot ${{ matrix.godot_version }} as "latest"
-      if: strategy.job-index == strategy.job-total - 1
       uses: elgohr/Publish-Docker-Github-Action@master
       env:
         GODOT_VERSION: ${{ matrix.godot_version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Note: The latest version must be at the very end (it will additionally be pushed as "latest")
         godot_version: ["3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.1", "3.1.1"]
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +21,16 @@ jobs:
         GODOT_VERSION: ${{ matrix.godot_version }}
       with:
         name: "gamedrivendesign/godot-export:${{ matrix.godot_version }}"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: GODOT_VERSION
+    - name: Push Godot ${{ matrix.godot_version }} as "latest"
+      if: strategy.job-index == strategy.job-total - 1
+      uses: elgohr/Publish-Docker-Github-Action@master
+      env:
+        GODOT_VERSION: ${{ matrix.godot_version }}
+      with:
+        name: "gamedrivendesign/godot-export:latest"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: GODOT_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,25 @@
 name: Publish to Docker
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - gh-actions # TODO: remove
+
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        godot_version: [3.0, 3.0.1]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Publish to Registry
+    - name: Build for Godot ${{ matrix.godot_version }}
       uses: elgohr/Publish-Docker-Github-Action@master
+      env:
+        GODOT_VERSION: ${{ matrix.godot_version }}
       with:
         name: gamedrivendesign/godot-export
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: GODOT_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - gh-actions # TODO: remove
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        godot_version: ["3.0", "3.0.1"]
+        godot_version: ["3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6", "3.1", "3.1.1"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - GAME_NAME="Awesome Game" GODOT_VERSION="3.0.2"
 
 install:
-- docker pull gamedrivendesign/godot-export
+- docker pull "gamedrivendesign/godot-export:${GODOT_VERSION}"
 
 # Each of the following lines exports the game for a given platform.
 # You can specify the platform in the EXPORT_NAME variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ services:
 - docker
 
 env:
-  # Use this to set your game's name. It is being used
+  # Use GAME_NAME to set your game's name. It is being used
   # throughout this file for naming exported artifacts.
   # This will, for example, create an "Awesome Game.exe"
-  - GAME_NAME="Awesome Game"
+  # Also set the Godot version you want to use here. Supported Godot versions can be
+  # found here: https://cloud.docker.com/u/gamedrivendesign/repository/docker/gamedrivendesign/godot-export/tags
+  # If your version is not available, please open an issue here: https://github.com/GameDrivenDesign/docker-godot-export
+  - GAME_NAME="Awesome Game" GODOT_VERSION="3.0.2"
 
 install:
 - docker pull gamedrivendesign/godot-export
@@ -15,10 +18,10 @@ install:
 # The exported game will be written to the folder specified after the second "-v" flag
 # "-v $(pwd)/output/html5:/build/output" writes the exported game to  the "output/html5" folder.
 script:
-- docker run -e EXPORT_NAME="HTML5"           -e OUTPUT_FILENAME="index.html"           -v $(pwd):/build/src -v $(pwd)/output/html5:/build/output   gamedrivendesign/godot-export
-- docker run -e EXPORT_NAME="Linux/X11"       -e OUTPUT_FILENAME="${GAME_NAME}"         -v $(pwd):/build/src -v $(pwd)/output/linux:/build/output   gamedrivendesign/godot-export
-- docker run -e EXPORT_NAME="Windows Desktop" -e OUTPUT_FILENAME="${GAME_NAME}.exe"     -v $(pwd):/build/src -v $(pwd)/output/windows:/build/output gamedrivendesign/godot-export
-- docker run -e EXPORT_NAME="Mac OSX"         -e OUTPUT_FILENAME="${GAME_NAME}-mac.zip" -v $(pwd):/build/src -v $(pwd)/output/mac:/build/output     gamedrivendesign/godot-export
+- docker run -e EXPORT_NAME="HTML5"           -e OUTPUT_FILENAME="index.html"           -v $(pwd):/build/src -v $(pwd)/output/html5:/build/output   "gamedrivendesign/godot-export:${GODOT_VERSION}"
+- docker run -e EXPORT_NAME="Linux/X11"       -e OUTPUT_FILENAME="${GAME_NAME}"         -v $(pwd):/build/src -v $(pwd)/output/linux:/build/output   "gamedrivendesign/godot-export:${GODOT_VERSION}"
+- docker run -e EXPORT_NAME="Windows Desktop" -e OUTPUT_FILENAME="${GAME_NAME}.exe"     -v $(pwd):/build/src -v $(pwd)/output/windows:/build/output "gamedrivendesign/godot-export:${GODOT_VERSION}"
+- docker run -e EXPORT_NAME="Mac OSX"         -e OUTPUT_FILENAME="${GAME_NAME}-mac.zip" -v $(pwd):/build/src -v $(pwd)/output/mac:/build/output     "gamedrivendesign/godot-export:${GODOT_VERSION}"
 
 # Now comes deployment related code.
 # To make this work, you need to set a GITHUB_TOKEN environment variable through

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@
 
 FROM alpine:edge
 
+ARG GODOT_VERSION
+
 WORKDIR /build
 
 RUN apk --no-cache add ca-certificates wget
@@ -20,14 +22,14 @@ RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/s
 	&& wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk \
 	&& apk add glibc-2.29-r0.apk
 
-RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/3.1.1/Godot_v3.1.1-stable_linux_server.64.zip -O /tmp/godot.zip \
+RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_linux_server.64.zip -O /tmp/godot.zip \
 	&& unzip -q -d /tmp /tmp/godot.zip \
 	&& mv /tmp/Godot* /build/godot
 
-RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/3.1.1/Godot_v3.1.1-stable_export_templates.tpz -O /tmp/export-templates.tpz \
+RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_export_templates.tpz -O /tmp/export-templates.tpz \
 	&& mkdir -p /tmp/data/godot/templates \
 	&& unzip -q -d /tmp/data/godot/templates /tmp/export-templates.tpz \
-	&& mv /tmp/data/godot/templates/templates /tmp/data/godot/templates/3.1.1.stable
+	&& mv /tmp/data/godot/templates/templates /tmp/data/godot/templates/$GODOT_VERSION.stable
 
 ENV XDG_CACHE_HOME /tmp/cache
 ENV XDG_DATA_HOME /tmp/data

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ You can also use the provided Docker image by itself.
 
 ## Dockerfile
 
-Use this Dockerfile to automatically export your game.
+Use this Dockerfile to automatically export your game. Choose the Godot version you
+want to use as the Docker image tag (e.g., 3.0.2 as shown below). Supported Godot
+versions can be found [here](https://cloud.docker.com/u/gamedrivendesign/repository/docker/gamedrivendesign/godot-export/tags). If your version is not available, please open an issue [in this repository](https://github.com/GameDrivenDesign/docker-godot-export).
 
 Set `EXPORT_NAME` to your template's name and `OUTPUT_FILENAME` accordingly.
 Add two volumes, one from your repository to `/build/src` and another to
@@ -20,7 +22,7 @@ E.g. inside your game's main folder (find the product in `/tmp/output`):
 docker run \
 	-e EXPORT_NAME="HTML5" \
 	-e OUTPUT_FILENAME="index.html" \
-	-v $(pwd):/build/src -v /tmp/output:/build/output gamedrivendesign/godot-export
+	-v $(pwd):/build/src -v /tmp/output:/build/output gamedrivendesign/godot-export:3.0.2
 ```
 
 ## Travis Integration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
   # throughout this file for naming exported artifacts.
   # This will, for example, create an "HareDerLage.exe"
   GAME_NAME: Awesome Game
+  # Set the Godot version you want to use here. Supported Godot versions can be
+  # found here: https://cloud.docker.com/u/gamedrivendesign/repository/docker/gamedrivendesign/godot-export/tags
+  # If your version is not available, please open an issue here: https://github.com/GameDrivenDesign/docker-godot-export
+  GODOT_VERSION: "3.0.2"
 
 # The following two lines can be enabled to allow a RDP connection to the machine
 # Connection details will be displayed in the build log.
@@ -51,21 +55,21 @@ before_build:
   # Install Godot
   - ps: |-
         if (!(Test-Path 'godot.exe')) {
-          Start-FileDownload 'https://downloads.tuxfamily.org/godotengine/3.0.2/Godot_v3.0.2-stable_win64.exe.zip'
-          7z x -tzip Godot_v3.0.2-stable_win64.exe.zip
-          rm Godot_v3.0.2-stable_win64.exe.zip
-          mv Godot_v3.0.2-stable_win64.exe godot.exe
+          Start-FileDownload "https://downloads.tuxfamily.org/godotengine/$env:GODOT_VERSION/Godot_v$env:GODOT_VERSION-stable_win64.exe.zip"
+          7z x -tzip "Godot_v$env:GODOT_VERSION-stable_win64.exe.zip"
+          rm "Godot_v$env:GODOT_VERSION-stable_win64.exe.zip"
+          mv "Godot_v$env:GODOT_VERSION-stable_win64.exe godot.exe"
         }
 
   # Install Godot export templates
   - ps: |-
         if (!(Test-Path 'templates')) {
-          Start-FileDownload 'https://downloads.tuxfamily.org/godotengine/3.0.2/Godot_v3.0.2-stable_export_templates.tpz' -fileName export_templates.tpz
+          Start-FileDownload "https://downloads.tuxfamily.org/godotengine/$env:GODOT_VERSION/Godot_v$env:GODOT_VERSION-stable_export_templates.tpz" -fileName export_templates.tpz
           7z x -tzip export_templates.tpz
           rm export_templates.tpz
         }
         mkdir -Force C:\Users\appveyor\AppData\Roaming\Godot\templates
-        cp -r templates C:\Users\appveyor\AppData\Roaming\Godot\templates\3.0.2.stable
+        cp -r templates "C:\Users\appveyor\AppData\Roaming\Godot\templates\$env:GODOT_VERSION.stable"
 
   # Install virtual audio device, otherwise Godot isn't able to export the game.
   - ps: |-


### PR DESCRIPTION
Since Docker still hasn't resolved the auto-build issues we were having, I have now changed the Docker build process to build all Docker images using GitHub actions. This also finally adds tagged images, so that games can specify the Godot version they want to use. An example action run can be found [here](https://github.com/GameDrivenDesign/docker-godot-export/commit/543074817dd8f8f67197a5b7988748a89f9e3928/checks?check_suite_id=291549348) and a list of now supported Godot versions [here](https://cloud.docker.com/u/gamedrivendesign/repository/docker/gamedrivendesign/godot-export/tags). The list of supported Godot versions must be manually maintained in the `.github/workflows/publish.yml` file.