### PR TITLE
Add github action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: 'Godot Export'
+description: 'Generate a godot binary from the repository'
+inputs:
+  export-template:  # id of input
+    description: 'Template name to use for exporting the project'
+    required: true
+  output-filename:
+    description: 'Name of the generated executable'
+    required: true
+  godot-version:
+    description: 'Version of godot required to build the project'
+    default: 'latest'
+outputs:
+runs:
+  using: 'docker'
+  image: 'docker://gamedrivendesign/godot-export:${{ inputs.godot-version }}' # use already built docker images
+  entrypoint: /build/godot 
+  args:
+    - --export '${{ inputs.export-template }}'
+    - --path /github/workspace
+    - '/github/workspace/output/${{ inputs.output-filename }}'


### PR DESCRIPTION
Action yml provided for use with Github Actions.  While this isn't necessary since you can just make a job using a docker file, this is helpful if you want to include additional steps.  I plan on doing things like also having an action to automatically upload the artifacts to itchio as well, so it's useful to have this as an actions.

Example workflow of how I'm using it with my game right now.  

```
name: CI

on: [push]

jobs:
  build:
    name: Export with Godot
    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v1
    - name: Generate windows binary
      uses: nhydock/docker-godot-export@master
      with:
        export-template: "Windows Desktop"
        output-filename: "adventure"
    - name: Upload binary executable
      uses: actions/upload-artifact@v1
      with:
        name: adventure.exe
        path: output/adventure.exe
    - name: Upload binary archives
      uses: actions/upload-artifact@v1
      with:
        name: adventure.pck
        path: output/adventure.pck
```