### PR TITLE
Use linux headless binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/s
 	&& wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk \
 	&& apk add glibc-2.29-r0.apk
 
-RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_linux_server.64.zip -O /tmp/godot.zip \
+RUN wget -q --waitretry=1 --retry-connrefused -T 10 https://downloads.tuxfamily.org/godotengine/$GODOT_VERSION/Godot_v$GODOT_VERSION-stable_linux_headless.64.zip -O /tmp/godot.zip \
 	&& unzip -q -d /tmp /tmp/godot.zip \
 	&& mv /tmp/Godot* /build/godot
 


### PR DESCRIPTION
Headless is made for tools and exporting from the cli, unlike server which is missing some key components and may not properly pack all resources.